### PR TITLE
Add loading and disabled state for Button component

### DIFF
--- a/lib/src/components/Button.js
+++ b/lib/src/components/Button.js
@@ -1,23 +1,27 @@
 // @flow
-import { TouchableOpacity, StyleSheet } from "react-native";
+import { ActivityIndicator, StyleSheet, TouchableOpacity } from "react-native";
 import React from "react";
 import SafeAreaView from "react-native-safe-area-view";
 
-import type { ThemeType } from "../config/theme";
 import Text from "./Text";
+import type { ThemeType } from "../config/theme";
 import withTheme from "../config/withTheme";
 
 const styles = {
-  wrapper: (theme: ThemeType) => ({
-    width: "100%",
+  wrapper: (theme: ThemeType, props: { fullWidth: boolean }) => ({
+    width: props.fullWidth ? "100%" : undefined,
+    minWidth: 100,
     alignItems: "center",
     justifyContent: "center",
     backgroundColor: theme.colors.primaryColor
   }),
-  button: (theme: ThemeType, props: Object) => ({
+  button: (theme: ThemeType, props: { bottom: boolean }) => ({
     paddingVertical: theme.button.paddingVertical + (props.bottom ? 10 : 0)
   }),
   buttonText: (theme: ThemeType) => ({
+    padding: 0,
+    height: 36,
+    lineHeight: 36,
     color: "white",
     fontSize: theme.button.textSize
   })
@@ -28,6 +32,9 @@ const Button = ({
   onPress,
   bottom,
   color,
+  loading,
+  disabled = false,
+  fullWidth = false,
   theme
 }: {
   /** Button text */
@@ -38,6 +45,12 @@ const Button = ({
   bottom: boolean,
   /** Background color of button */
   color: string,
+  /** Loading state, change the button text to loading indicator. Button is disabled when loading */
+  loading: boolean,
+  /** When disabled, button cannot be clicked and have gray color */
+  disabled: boolean,
+  /** Display button with width is 100% of its parent*/
+  fullWidth: boolean,
   /**
    *
    * @ignore
@@ -45,18 +58,29 @@ const Button = ({
   theme: ThemeType
 }) => (
   <TouchableOpacity
+    disabled={disabled || loading}
     onPress={onPress}
     style={StyleSheet.flatten([
-      styles.wrapper(theme),
-      { backgroundColor: color ? color : theme.colors.primaryColor },
+      styles.wrapper(theme, { fullWidth: fullWidth || bottom }),
+      {
+        backgroundColor: disabled
+          ? theme.button.disabledColor
+          : color
+          ? color
+          : theme.colors.primaryColor
+      },
       { borderRadius: bottom ? 0 : theme.button.borderRadius }
     ])}
   >
     <SafeAreaView
       forceInset={{ bottom: bottom ? "always" : "never" }}
-      style={styles.button(theme, { bottom })}
+      style={styles.button(theme, { bottom, disabled })}
     >
-      <Text style={styles.buttonText(theme)}>{children}</Text>
+      {loading ? (
+        <ActivityIndicator size="large" />
+      ) : (
+        <Text style={styles.buttonText(theme)}>{children}</Text>
+      )}
     </SafeAreaView>
   </TouchableOpacity>
 );

--- a/lib/src/components/__tests__/Button.test.js
+++ b/lib/src/components/__tests__/Button.test.js
@@ -1,7 +1,52 @@
-import Button from "../Button";
+import React from "react";
 
-describe("Something", () => {
-  it("tests something", () => {
-    expect(true).toEqual(true);
+import ThemeProvider from "../../config/ThemeProvider";
+import Button from "../Button";
+import { getTheme } from "../../config/theme";
+import renderer from "react-test-renderer";
+
+const theme = getTheme();
+
+describe("Button", () => {
+  describe("When button at the bottom", () => {
+    it("renders correctly", () => {
+      const component = renderer.create(
+        <ThemeProvider theme={theme}>
+          <Button theme={theme} bottom>
+            Bottom Button
+          </Button>
+        </ThemeProvider>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe("Button is loading", () => {
+    it("renders correctly", () => {
+      const component = renderer.create(
+        <ThemeProvider theme={theme}>
+          <Button theme={theme} loading>
+            Loading Button
+          </Button>
+        </ThemeProvider>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe("Button is disabled", () => {
+    it("renders correctly", () => {
+      const component = renderer.create(
+        <ThemeProvider theme={theme}>
+          <Button theme={theme} disabled>
+            Disabled Button
+          </Button>
+        </ThemeProvider>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
   });
 });

--- a/lib/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/lib/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -1,0 +1,151 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button Button is disabled renders correctly 1`] = `
+<View
+  accessible={true}
+  isTVSelectable={true}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#aaaaaa",
+      "borderRadius": 4,
+      "justifyContent": "center",
+      "minWidth": 100,
+      "opacity": 1,
+      "width": undefined,
+    }
+  }
+>
+  <View
+    onLayout={[Function]}
+    pointerEvents="box-none"
+    style={
+      Object {
+        "paddingBottom": 10,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 20,
+          "fontWeight": "400",
+          "height": 36,
+          "lineHeight": 36,
+          "padding": 0,
+        }
+      }
+    >
+      Loading Button
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`Button Button is loading renders correctly 1`] = `
+<View
+  accessible={true}
+  isTVSelectable={true}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#003580",
+      "borderRadius": 4,
+      "justifyContent": "center",
+      "minWidth": 100,
+      "opacity": 1,
+      "width": undefined,
+    }
+  }
+>
+  <View
+    onLayout={[Function]}
+    pointerEvents="box-none"
+    style={
+      Object {
+        "paddingBottom": 10,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 20,
+      }
+    }
+  >
+    <ActivityIndicator
+      animating={true}
+      color="#999999"
+      hidesWhenStopped={true}
+      size="large"
+    />
+  </View>
+</View>
+`;
+
+exports[`Button When button at the bottom renders correctly 1`] = `
+<View
+  accessible={true}
+  isTVSelectable={true}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#003580",
+      "borderRadius": 0,
+      "justifyContent": "center",
+      "minWidth": 100,
+      "opacity": 1,
+      "width": "100%",
+    }
+  }
+>
+  <View
+    onLayout={[Function]}
+    pointerEvents="box-none"
+    style={
+      Object {
+        "paddingBottom": 20,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 20,
+          "fontWeight": "400",
+          "height": 36,
+          "lineHeight": 36,
+          "padding": 0,
+        }
+      }
+    >
+      Bottom Button
+    </Text>
+  </View>
+</View>
+`;

--- a/lib/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/lib/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -47,7 +47,7 @@ exports[`Button Button is disabled renders correctly 1`] = `
         }
       }
     >
-      Loading Button
+      Disabled Button
     </Text>
   </View>
 </View>

--- a/lib/src/config/theme.js
+++ b/lib/src/config/theme.js
@@ -50,7 +50,8 @@ const theme: ThemeType = {
   },
   button: {
     textSize: normalizeText(16),
-    paddingVertical: 15,
+    paddingVertical: 10,
+    disabledColor: "#aaaaaa",
     borderRadius: 4
   },
   input: {
@@ -111,6 +112,7 @@ export type ThemeType = {
   button: {
     textSize: number,
     paddingVertical: number,
+    disabledColor: "#aaaaaa",
     borderRadius: number
   },
   input: {

--- a/sandbox/stories/Button.js
+++ b/sandbox/stories/Button.js
@@ -16,18 +16,49 @@ const styles = StyleSheet.create({
 });
 
 class ButtonScreen extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { loading: false };
+  }
+  toggle = () => {
+    this.setState({ loading: !this.state.loading });
+  };
   render() {
     return (
       <View style={styles.container}>
+        <Button
+          loading={this.state.loading}
+          onPress={this.toggle}
+          color="green"
+        >
+          Button
+        </Button>
         <View style={styles.pusher}>
           <TextInput
             placeholder="Enter your email"
             noBorder
             inputStyle={{ backgroundColor: "#eee" }}
           />
+          <Button
+            loading={this.state.loading}
+            onPress={this.toggle}
+            color="green"
+          >
+            Button
+          </Button>
+          <Button
+            loading={this.state.loading}
+            onPress={this.toggle}
+            color="pink"
+            disabled
+          >
+            Disabled Button
+          </Button>
           <Button color="red">Button</Button>
         </View>
-        <Button bottom>Button</Button>
+        <Button loading bottom>
+          Button
+        </Button>
       </View>
     );
   }


### PR DESCRIPTION
# Summary
Add 2 new states for button: `Loading` and `Disabled`
- Loading: Display `LoadingIndicator` instead of the button text. In this state, `onPress` is disabled.
- Disabled: Display button as `gray` color and `onPress` is disabled. Dev can customize disable color in `theme`.

# Screenshot
<img width="252" alt="iPhone X — 12 4 2019-08-26 10-21-07" src="https://user-images.githubusercontent.com/6701979/63663187-9e626000-c7eb-11e9-8ed9-4b73703c31c7.png">|
<img width="230" alt="iPhone X — 12 4 2019-08-26 10-22-44" src="https://user-images.githubusercontent.com/6701979/63663191-a1f5e700-c7eb-11e9-8f6c-8f058ab56cc5.png">
-|-
Normal | Loading